### PR TITLE
Implemented auto dial feature

### DIFF
--- a/Smsgh.UssdFramework/UssdContext.cs
+++ b/Smsgh.UssdFramework/UssdContext.cs
@@ -15,7 +15,7 @@ namespace Smsgh.UssdFramework
         private string NextRouteKey { get { return Request.Mobile + "NextRoute"; } }
         private string DataBagKey { get { return Request.Mobile + "DataBag"; } }
         private Func<Task<UssdResponse>> Action { get; set; }
-        private UssdRequest Request { get; set; }
+        public UssdRequest Request { get; private set; }
         private IStore Store { get; set; }
         private Dictionary<string, string> Data { get; set; } 
         private UssdDataBag DataBag { get; set; }

--- a/Smsgh.UssdFramework/UssdRequest.cs
+++ b/Smsgh.UssdFramework/UssdRequest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,6 +15,10 @@ namespace Smsgh.UssdFramework
         public string Type { get; set; }
         public string Message { get; set; }
         public string Operator { get; set; }
+        [JsonIgnore]
+        public int AutoDialIndex { get; set; }
+        [JsonIgnore]
+        public bool AutoDialOriginated { get; set; }
 
         public UssdRequestTypes RequestType 
         {

--- a/Smsgh.UssdFramework/UssdResponse.cs
+++ b/Smsgh.UssdFramework/UssdResponse.cs
@@ -16,12 +16,14 @@ namespace Smsgh.UssdFramework
         public UssdResponse()
         {
             Exception = null;
+            AutoDialOn = true;
         }
 
 
         public string NextRoute { get; private set; }
         public bool IsRelease { get { return string.IsNullOrWhiteSpace(NextRoute); } }
         public bool IsRedirect { get; private set; }
+        public bool AutoDialOn { get; set; }
 
         public static UssdResponse Render(string message, string nextRoute = null)
         {


### PR DESCRIPTION
## Auto Dial Feature

Implemented auto dial feature, i.e. being able to treat \*714\*2\*3\*1\*2# as equivalent to entering \*714#,
followed by 2, 3, 1 and 2.

Most ussd apps should work without modification. A few ussd apps may want to prevent auto dial at a certain stage in their screens, so that users explicity enter the input on those screens. For this scenario, the UssdResponse class was given an AutoDialOn property which can be set to false to "break" the auto dial session at any time in the processing of initiation messages (the only time that auto dial mechanism kicks in).